### PR TITLE
Adding 'make shared' to build libccronexpr.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmake-build*/
 *.o
 supertinycron
 ccronexpr_test
+libccronexpr.so

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,22 @@ else
     VERSION := $(VERSION)-dev-build
 endif
 CFLAGS = -Wextra -std=c89 -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-z,norelro -Wno-unused-parameter -static -DVERSION=\"$(VERSION)\" -DCRON_USE_LOCAL_TIME
-CFLAGS = -Wextra -std=c89 -s -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-z,norelro -static -DVERSION=\"$(VERSION)\" -DCRON_USE_LOCAL_TIME
+CFLAGS = -Wextra -std=c89 -s -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-z,norelro -static -DVERSION=\"$(VERSION)\" -DCRON_USE_LOCAL_TIME -fPIC
 SOURCES = supertinycron.c ccronexpr.c ccronexpr_test.c
 OBJECTS = supertinycron.o ccronexpr.o
 OBJECTS_TEST = ccronexpr_test.o ccronexpr.o
+OBJECTS_SHARED = ccronexpr.o
 EXECUTABLE = supertinycron
 EXECUTABLE_TEST = ccronexpr_test
+SHARED = libccronexpr.so
+LDFLAGS = -shared -Wl,-soname,$(SHARED) -fPIC
 
 all: $(EXECUTABLE) $(EXECUTABLE_TEST)
+
+shared: $(SHARED)
+
+$(SHARED): $(OBJECTS_SHARED)
+	$(CC) $(LDFLAGS) $^ -o $@
 
 $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $(OBJECTS) -o $@
@@ -24,4 +32,4 @@ $(EXECUTABLE_TEST): $(OBJECTS_TEST)
 	$(CC) $(CFLAGS) $(OBJECTS_TEST) -o $@
 
 clean:
-	rm -f $(OBJECTS) $(OBJECTS_TEST) $(EXECUTABLE) $(EXECUTABLE_TEST)
+	rm -f $(OBJECTS) $(OBJECTS_TEST) $(EXECUTABLE) $(EXECUTABLE_TEST) $(SHARED)


### PR DESCRIPTION
supertinycron/ccronexpr has a usefull functionality, which can be included in other software .
Here I add `make shared` to build `libccronexpr.so`, so it can be imported by other programs.