### PR TITLE
Add make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ EXECUTABLE = supertinycron
 EXECUTABLE_TEST = ccronexpr_test
 SHARED = libccronexpr.so
 LDFLAGS = -shared -Wl,-soname,$(SHARED) -fPIC
+INSTALL_DIR = /usr/local/bin
 
 all: $(EXECUTABLE) $(EXECUTABLE_TEST)
 
@@ -30,6 +31,12 @@ $(EXECUTABLE): $(OBJECTS)
 
 $(EXECUTABLE_TEST): $(OBJECTS_TEST)
 	$(CC) $(CFLAGS) $(OBJECTS_TEST) -o $@
+
+install: $(EXECUTABLE)
+	cp $(EXECUTABLE) $(INSTALL_DIR)
+
+uninstall:
+	rm -f $(INSTALL_DIR)/$(EXECUTABLE)
 
 clean:
 	rm -f $(OBJECTS) $(OBJECTS_TEST) $(EXECUTABLE) $(EXECUTABLE_TEST) $(SHARED)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Installing
 ----------
 
 ```bash
-make
-sudo mv supertinycron /usr/local/bin/
+make install
 ```
 
 Usage


### PR DESCRIPTION
The binary can now be installed by running `make install` and removed by `make uninstall`. This simplifies both manual installation and packaging.