### PR TITLE
Fix: clang-tidy warns #17

### DIFF
--- a/ccronexpr.c
+++ b/ccronexpr.c
@@ -600,11 +600,11 @@ static int generate_field(char *dest, uint8_t *bits, int min, int max, int offse
         }
     }
     if (from == i - 1) {
-        if (first) first = 0; else STRCATC(dest, ",", 1);
+        if (!first) STRCATC(dest, ",", 1);
         STRCATC(dest, buf, sprintf(buf, "%d", from));
     } else if (from == min && i == max) STRCATC(dest, "*", 1);
     else if (from != -1) {
-        if (first) first = 0; else STRCATC(dest, ",", 1);
+        if (!first) STRCATC(dest, ",", 1);
         STRCATC(dest, buf, sprintf(buf, "%d-%d", from, i - 1));
     }
     return len;
@@ -664,6 +664,8 @@ int cron_generate_expr(cron_expr *source, char *buffer, int buffer_len, int cron
         }
     }
 #endif
+
+    (void)error;
     return len;
 }
 


### PR DESCRIPTION

My guess for the `error` in `cron_generate_expr` is that it will be used soon, but untill is better to mark it as (void) or just delete it. 
About the assignment of `first` it is not `static` and we don't need to assign any value at the end of the function. Just validate and return.
Closing issue: #17 