### PR TITLE
Fix potential buffer overflow by resizing buffer

### DIFF
--- a/ccronexpr.c
+++ b/ccronexpr.c
@@ -591,7 +591,7 @@ static int do_nextprev(cron_expr* expr, struct tm* calendar, int dot, int offset
 }
 
 static int generate_field(char *dest, uint8_t *bits, int min, int max, int offset, int overflow, int buffer_len) {
-    char  buf[32];
+    char buf[33];
     int len = 0, first = 1, i, fs = -1, ls = -1, d = -1, n = 0, from, dt;
     for (i = min; i < max; i++) {
         if (cron_get_bit(bits, i + offset)) {


### PR DESCRIPTION
Increased the size of the buf array in generate_field from 32 to 33 bytes to ensure it can safely accommodate the largest possible string generated by sprintf.
The new size accounts for a worst-case scenario where the formatted string includes three maximum-sized 32-bit integers, two delimiters (- and /), and a null terminator.

This change resolves a compiler warning (uClibc) about potential overflows (-Werror=format-overflow).